### PR TITLE
Add sqlserver config options: DefaultStringSize.

### DIFF
--- a/sqlserver.go
+++ b/sqlserver.go
@@ -17,9 +17,10 @@ import (
 )
 
 type Config struct {
-	DriverName string
-	DSN        string
-	Conn       gorm.ConnPool
+	DriverName        string
+	DSN               string
+	DefaultStringSize string
+	Conn              gorm.ConnPool
 }
 
 type Dialector struct {
@@ -172,7 +173,11 @@ func (dialector Dialector) DataTypeOf(field *schema.Field) string {
 		size := field.Size
 		hasIndex := field.TagSettings["INDEX"] != "" || field.TagSettings["UNIQUE"] != ""
 		if (field.PrimaryKey || hasIndex) && size == 0 {
-			size = 256
+			if dialector.DefaultStringSize > 0 {
+				size = dialector.DefaultStringSize
+			} else {
+				size = 256
+			}
 		}
 		if size > 0 && size <= 4000 {
 			return fmt.Sprintf("nvarchar(%d)", size)


### PR DESCRIPTION
Add sqlserver config options: DefaultStringSize.

for example:

	sqlserverConf := sqlserver.Config{
		DSN:               dns,
		DefaultStringSize: 50,
	}