### PR TITLE
fixed int data type selection based on size

### DIFF
--- a/sqlserver.go
+++ b/sqlserver.go
@@ -157,8 +157,10 @@ func (dialector Dialector) DataTypeOf(field *schema.Field) string {
 		var sqlType string
 		switch {
 		case field.Size < 16:
-			sqlType = "smallint"
+			sqlType = "tinyint"
 		case field.Size < 31:
+			sqlType = "smallint"
+		case field.Size < 64:
 			sqlType = "int"
 		default:
 			sqlType = "bigint"


### PR DESCRIPTION
**Pull request title**
integer data type selection by sizing should be fixed

***

**Conventions**
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

****

**Pull request reason**
Fix sql server integer type selection based on go lang int value memory size

***

**User Case Description**

https://github.com/go-gorm/sqlserver/blob/3c1621020dc4503717a93f7e7b9eb38c623aaa12/sqlserver.go#L158


SQL Server datatype selection based on int value data size is not appropriate. Here is the condition

```go

switch {
case field.Size < 16:
	sqlType = "smallint"
case field.Size < 31:
	sqlType = "int"
default:
	sqlType = "bigint"
}

```


Golang integers
 * `int8 : 1 byte or 8 bits`
 * `int16: 2 bytes or 16 bits`
 * `int32: 3 bytes or 32 bits`
 * `int64` 4 bytes or 64 bits`
 
 SQL Server integers equivalent
  * `tinyint : int8`
  * `smallint : int16`
  * `int : int32`
  * `biging : int64`
 

The condition should be

```go

switch {
case field.Size < 16:
	sqlType = "tinyint"
case field.Size < 31:
	sqlType = "smallint"
case field.Size < 64:
	sqlType = "int"
default:
	sqlType = "bigint"
}

```


)
