### PR TITLE
Updated Regexp to handle correctly string values

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -144,7 +144,7 @@ func (m Migrator) RenameColumn(value interface{}, oldName, newName string) error
 	})
 }
 
-var defaultValueTrimRegexp = regexp.MustCompile("^\\('?(.*)'?\\)$")
+var defaultValueTrimRegexp = regexp.MustCompile("^\\('?([^']*)'?\\)$")
 
 // ColumnTypes return columnTypes []gorm.ColumnType and execErr error
 func (m Migrator) ColumnTypes(value interface{}) ([]gorm.ColumnType, error) {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

A simple regexp adjustment to improve the handling of string default values.

### User Case Description

<!-- Your use case -->

Let's take as an example a column with a default value of `C`.

MSSQL would return this default value as `('C')` when querying the schema.

With the old regexp the parsed field would be returned as `C'` (note the extra `'` at the end), meaning that every column with a string default value would be updated every time the Automigration triggers.

Debugger result of the example

![regex-error](https://user-images.githubusercontent.com/76876154/158608112-9e6f5dd9-e8b0-4019-8f12-537b8c8ff1aa.png)

**The updated regex solves this issue**


