### PR TITLE
修复 Limit 为 0 时查询报错：mssql: 为 FETCH 子句提供的行数必须大于零。

### DIFF
--- a/sqlserver.go
+++ b/sqlserver.go
@@ -87,7 +87,7 @@ func (dialector Dialector) ClauseBuilders() map[string]clause.ClauseBuilder {
 					builder.WriteString(" ROWS")
 				}
 
-				if limit.Limit != nil && *limit.Limit >= 0 {
+				if limit.Limit != nil && *limit.Limit > 0 {
 					if limit.Offset == 0 {
 						builder.WriteString("OFFSET 0 ROW")
 					}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

修复 Limit 为 0 时查询报错：mssql: 为 FETCH 子句提供的行数必须大于零。

### User Case Description

![image](https://user-images.githubusercontent.com/23544702/194746716-2764a869-6350-46f9-a216-abb336d2339b.png)

```go
result := tx.Model(&Cron{}).Order("created_at").Offset(0).Limit(0).Find(&list)
// SELECT * FROM "crons" WHERE "crons"."deleted_at" IS NULL ORDER BY created_at OFFSET 0 ROW FETCH NEXT 0 ROWS ONLY
if err := result.Error; err != nil {
    log.Println(err.Error()) // mssql: 为 FETCH 子句提供的行数必须大于零。
}
```
