### PR TITLE
Fix merge into statment when adding schema name using NamingStrategy

### DIFF
--- a/create.go
+++ b/create.go
@@ -135,7 +135,7 @@ func Create(db *gorm.DB) {
 
 func MergeCreate(db *gorm.DB, onConflict clause.OnConflict, values clause.Values) {
 	db.Statement.WriteString("MERGE INTO ")
-	db.Statement.WriteQuoted(db.Statement.Table)
+	db.Statement.WriteQuoted(db.Statement.DB.NamingStrategy.TableName(db.Statement.Table))
 	db.Statement.WriteString(" USING (VALUES")
 	for idx, value := range values.Values {
 		if idx > 0 {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Fixing MERGE INTO statement when user added schema as TablePrefix 

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

When user set schema name using schema.NamingStrategy almost everything works except MERGE INTO statement, it was failing because the schema name wasn't added in the raw SQL statement

for example here I set MySchema as schema in a sql server database

```
db, err := gorm.Open(sqlserver.Open(connStr), &gorm.Config{
NamingStrategy: schema.NamingStrategy{
	TablePrefix:   "MySchema.",
	SingularTable: false,
}})
```

When I bulk insert multiple records to a table using the following code

```
db.Save(&recordsArray)
```

The following error will show up 
```
mssql: Invalid object name 'MyTable'.
[0.802ms] [rows:0] MERGE INTO "MyTable" USING ...
```
where the correct table name should be MySchema.MyTable

<!-- Your use case -->
