### PR TITLE
fix: error translation casting

### DIFF
--- a/error_translator.go
+++ b/error_translator.go
@@ -6,6 +6,7 @@ import (
 	"gorm.io/gorm"
 )
 
+// The error codes to map mssql errors to gorm errors, here is a reference about error codes for mssql https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors?view=sql-server-ver16
 var errCodes = map[string]int32{
 	"uniqueConstraint": 2627,
 }
@@ -17,7 +18,7 @@ type ErrMessage struct {
 
 // Translate it will translate the error to native gorm errors.
 func (dialector Dialector) Translate(err error) error {
-	if mssqlErr, ok := err.(*mssql.Error); ok {
+	if mssqlErr, ok := err.(mssql.Error); ok {
 		if mssqlErr.Number == errCodes["uniqueConstraint"] {
 			return gorm.ErrDuplicatedKey
 		}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

After writing ErrDuplicatedKey integration test coverage for Gorm we noticed that it is failing for this driver, it was because we were casting the mssql error with a pointer but it should be cast without a pointer.

Here is a screenshot from CI:

<img width="990" alt="Screenshot at Jun 08 23-26-47" src="https://github.com/go-gorm/sqlserver/assets/29974712/c639ea29-61fc-450c-839e-bbedcf9224c0">

