### PR TITLE
aware table schema on function ColumnTypes

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -215,9 +215,20 @@ func (m Migrator) ColumnTypes(value interface{}) ([]gorm.ColumnType, error) {
 		rows.Close()
 
 		{
+			_, schemaName, tableName := splitFullQualifiedName(stmt.Table)
+
+			query := "SELECT COLUMN_NAME, DATA_TYPE, COLUMN_DEFAULT, IS_NULLABLE, CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX, NUMERIC_SCALE, DATETIME_PRECISION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_CATALOG = ? AND TABLE_NAME = ?"
+
+			queryParameters := []interface{}{m.CurrentDatabase(), tableName}
+
+			if schemaName != "" {
+				query += " AND TABLE_SCHEMA = ?"
+				queryParameters = append(queryParameters, schemaName)
+			}
+
 			var (
-				columnTypeSQL   = "SELECT COLUMN_NAME, DATA_TYPE, COLUMN_DEFAULT, IS_NULLABLE, CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX, NUMERIC_SCALE, DATETIME_PRECISION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_CATALOG = ? AND TABLE_NAME = ?"
-				columns, rowErr = m.DB.Raw(columnTypeSQL, m.CurrentDatabase(), stmt.Table).Rows()
+				columnTypeSQL   = query
+				columns, rowErr = m.DB.Raw(columnTypeSQL, queryParameters...).Rows()
 			)
 
 			if rowErr != nil {
@@ -272,7 +283,17 @@ func (m Migrator) ColumnTypes(value interface{}) ([]gorm.ColumnType, error) {
 		}
 
 		{
-			columnTypeRows, err := m.DB.Raw("SELECT c.COLUMN_NAME, t.CONSTRAINT_TYPE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS t JOIN INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE c ON c.CONSTRAINT_NAME=t.CONSTRAINT_NAME WHERE t.CONSTRAINT_TYPE IN ('PRIMARY KEY', 'UNIQUE') AND c.TABLE_CATALOG = ? AND c.TABLE_NAME = ?", m.CurrentDatabase(), stmt.Table).Rows()
+			_, schemaName, tableName := splitFullQualifiedName(stmt.Table)
+			query := "SELECT c.COLUMN_NAME, t.CONSTRAINT_TYPE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS t JOIN INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE c ON c.CONSTRAINT_NAME=t.CONSTRAINT_NAME WHERE t.CONSTRAINT_TYPE IN ('PRIMARY KEY', 'UNIQUE') AND c.TABLE_CATALOG = ? AND c.TABLE_NAME = ?"
+
+			queryParameters := []interface{}{m.CurrentDatabase(), tableName}
+
+			if schemaName != "" {
+				query += " AND c.TABLE_SCHEMA = ?"
+				queryParameters = append(queryParameters, schemaName)
+			}
+
+			columnTypeRows, err := m.DB.Raw(query, queryParameters...).Rows()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
This pull request addresses an issue in the ColumnTypes function where only tables within the dbo schema are successfully generated. The update modifies the function to properly handle table names that belong to different schemas, ensuring that tables in schemas other than dbo are also correctly processed and their column types are retrieved.

### User Case Description

<!-- Your use case -->
Currently, when a user attempts to retrieve column types for tables located in schemas other than dbo, the ColumnTypes function fails to recognize the schema.
