### PR TITLE
Add error code 2601

### DIFF
--- a/error_translator.go
+++ b/error_translator.go
@@ -9,6 +9,7 @@ import (
 // The error codes to map mssql errors to gorm errors, here is a reference about error codes for mssql https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors?view=sql-server-ver16
 var errCodes = map[int32]error{
 	2627: gorm.ErrDuplicatedKey,
+	2601: gorm.ErrDuplicatedKey,
 	547:  gorm.ErrForeignKeyViolated,
 }
 

--- a/error_translator_test.go
+++ b/error_translator_test.go
@@ -28,6 +28,11 @@ func TestDialector_Translate(t *testing.T) {
 			want: gorm.ErrDuplicatedKey,
 		},
 		{
+			name: "it should return ErrDuplicatedKey error if the error number is 2601",
+			args: args{err: mssql.Error{Number: 2601}},
+			want: gorm.ErrDuplicatedKey,
+		},
+		{
 			name: "it should return ErrForeignKeyViolated the error number is 547",
 			args: args{err: mssql.Error{Number: 547}},
 			want: gorm.ErrForeignKeyViolated,


### PR DESCRIPTION



- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

Adds error code 2601 to be represented as `gorm.ErrDuplicatedKey` in the error translator.

### User Case Description

SQL Server have two slightly different error codes for duplicate key errors: 2627 occurs on unique/PK constraint violations, while 2601 is triggered by unique index violations. Both indicate duplicate keys but stem from different schema definitions.

#### Description from sqlserver
```sql
select * from sysmessages where (error = 2627 or error = 2601) and msglangid = 1033
```

|error|severity|dlevel|description|msglangid|
|---|---|---|---|---|
|2601|14|0|Cannot insert duplicate key row in object &#39;%.*ls&#39; with unique index &#39;%.*ls&#39;. The duplicate key value is %ls.|1033|
|2627|14|0|Violation of %ls constraint &#39;%.*ls&#39;. Cannot insert duplicate key in object &#39;%.*ls&#39;. The duplicate key value is %ls.|1033|