### PR TITLE
patch has constraint method for sql server driver

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -572,7 +572,7 @@ func (m Migrator) HasConstraint(value interface{}, name string) bool {
 		}
 
 		return m.DB.Raw(
-			`SELECT count(*) FROM sys.foreign_keys as F inner join sys.tables as T on F.parent_object_id=T.object_id inner join INFORMATION_SCHEMA.TABLES as I on I.TABLE_NAME = T.name WHERE F.name = ?  AND I.TABLE_NAME = ? AND I.TABLE_SCHEMA like ? AND I.TABLE_CATALOG = ?;`,
+			`SELECT count(*) FROM sys.check_constraints as C inner join sys.tables as T on C.parent_object_id=T.object_id inner join INFORMATION_SCHEMA.TABLES as I on I.TABLE_NAME = T.name WHERE C.name = ?  AND I.TABLE_NAME = ? AND I.TABLE_SCHEMA like ? AND I.TABLE_CATALOG = ?;`,
 			name, tableName, tableSchema, tableCatalog,
 		).Row().Scan(&count)
 	})


### PR DESCRIPTION
- [ x ] Do only one thing
- [ x ] Non breaking API changes
- [ x ] Tested

### What did this pull request do?

In this PR, the HasConstraint function has been patched, to query the correct table (sys.check_constraints) in SQL server.

### User Case Description

I am using check constraints with GORM, however, every time I run the auto migrate, it will try to create the check constraints over and over again, even though they already exist. After some investigation, I came across this query, which will run on the wrong table: sys.foreign_keys, which should be: sys.check_constraints.
